### PR TITLE
Make it easier to retain application state across Sign In With Twitter dance.

### DIFF
--- a/le_social/twitter/views.py
+++ b/le_social/twitter/views.py
@@ -37,7 +37,7 @@ class Authorize(generic.View, OAuthMixin):
     in the session and redirects to twitter.
     """
     def get(self, request, *args, **kwargs):
-        callback = self.build_callback(request, *args, **kwargs)
+        callback = self.build_callback()
         auth = tweepy.OAuthHandler(self.get_consumer_key(),
                                    self.get_consumer_secret(),
                                    secure=True,
@@ -47,7 +47,7 @@ class Authorize(generic.View, OAuthMixin):
                                             auth.request_token.secret)
         return redirect(url)
     
-    def build_callback(self, request, *args, **kwargs):
+    def build_callback(self):
         """ Override this if you'd like to specify a callback URL"""
         return None
 
@@ -82,9 +82,9 @@ class Return(generic.View, OAuthMixin):
         except tweepy.TweepError as e:
             return self.error('Failed to get an access token')
 
-        return self.success(auth, request, *args, **kwargs)
+        return self.success(auth)
 
-    def success(self, auth, request, *args, **kwargs):
+    def success(self, auth):
         """
         Twitter authentication successful, do some stuff with his key.
         """


### PR DESCRIPTION
I added the ability to specify a custom callback URL, and provided access to the request object in Return.success()

Custom callback URLs are pretty useful, especially if you'd like to preserve application state via some URL key. It's also possible to accomplish this using the sessions API, but then you need access to the request object in Return.success() as well.
