### PR TITLE
Strip the email subject's rendered string

### DIFF
--- a/le_social/registration/views.py
+++ b/le_social/registration/views.py
@@ -78,7 +78,8 @@ class Register(generic.FormView):
     def send_notification(self):
         context = self.get_notification_context()
         send_mail(
-            render_to_string(self.notification_subject_template_name, context),
+            render_to_string(self.notification_subject_template_name, context
+            ).strip(),
             render_to_string(self.notification_template_name, context),
             settings.DEFAULT_FROM_EMAIL,
             [self.user.email],


### PR DESCRIPTION
When not striping the rendered string for the email subject, you could encounter this kind of error when trying to send the email notification:

``` python
BadHeaderError at /register/
Header values can't contain newlines (got u'account activation\n' for header 'Subject')
```

Example template (with no newline at the end of the file):

```
account activation
```

To prevent that, `strip()` the rendered string.
