### PR TITLE
Change "from registration" to "from ." in registration/urls.py for docs  

### DIFF
--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -53,7 +53,7 @@ Add some URLs in ``registration/urls.py``:
 
     from django.conf.urls import patterns, url
 
-    from registration import views
+    from . import views
 
     urlpatterns = patterns('',
         url(r'^activate/complete/$', views.activation_complete,


### PR DESCRIPTION
Maybe better with . than "registration", if someone call otherwise than "registration".
